### PR TITLE
Fix inverted val_source condition in loaders.py causing ConfigKeyError

### DIFF
--- a/src/tasks/loaders.py
+++ b/src/tasks/loaders.py
@@ -262,7 +262,7 @@ def create_dataloaders(
     # load datasets
     if config.experiment.test:
         dataset_list = task_cfg.test_source
-    elif task_cfg.val_source is None and not training:
+    elif task_cfg.val_source is not None and not training:
         dataset_list = task_cfg.val_source
     else:
         dataset_list = copy.deepcopy(task_cfg.source)


### PR DESCRIPTION
During validation, the condition `task_cfg.val_source is None` was inverted, causing the code to fall through to `task_cfg.source` (which includes augmentation-only datasets like R2R_SCALEVLN, R2R_PREVALENT, REVERIE_SCALEVLN) instead of using `val_source`. These aug-only datasets have no eval_splits entries, triggering:
  omegaconf.errors.ConfigKeyError: Missing key R2R_SCALEVLN

Fix: change `is None` to `is not None` so val_source is used when it is defined and we are not in training mode.

Fixes #6